### PR TITLE
python 3.5 => 3.6

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN apt-get update
 RUN apt-get install --yes redis-tools

--- a/Dockerfile-import
+++ b/Dockerfile-import
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN apt-get update
 RUN apt-get -qy install git wget


### PR DESCRIPTION
https://github.com/addok/addok documentation now recommends 3.6 (and tests against 3.6 on Travis-CI integration test platform).